### PR TITLE
Handle timeouts in GET calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,3 +10,4 @@ jobs:
       - run: mix local.rebar --force
       - run: mix deps.get
       - run: mix test
+      - run: mix format --check-formatted

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.5.2
+      - image: circleci/elixir:1.6
     working_directory: ~/repo
     steps:
       - checkout

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add `peerage_ec2` to your list of dependencies in mix.exs:
 ```elixir
     def deps do
       [
-        {:peerage_ec2, "~> 1.1.0"},
+        {:peerage_ec2, "~> 1.2.0"},
       ]
     end
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,9 @@
 use Mix.Config
 
 config :peerage, via: Peerage.Via.Ec2
-config :peerage_ec2, aws_access_key_id: "example",
-                     aws_secret_access_key: "key",
-                     tags: [{:cluster, "cluster"}, {:service, "service"}]
+
+config :peerage_ec2,
+  aws_access_key_id: "example",
+  aws_secret_access_key: "key",
+  tags: [{:cluster, "cluster"}, {:service, "service"}],
+  timeout: 1000

--- a/lib/peerage/via/ec2.ex
+++ b/lib/peerage/via/ec2.ex
@@ -22,13 +22,15 @@ defmodule Peerage.Via.Ec2 do
     #
     # AWS Documentation: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
     metadata_api = 'http://169.254.169.254/latest/meta-data/instance-id'
-    case :httpc.request(metadata_api) do
+
+    case request(metadata_api) do
       {:ok, {{_, 200, _}, _headers, body}} -> to_string(body)
       _ -> :error
     end
   end
 
   defp fetch_cluster_name(:error), do: :error
+
   defp fetch_cluster_name(instance_id) do
     # Having retrieved the instance_id of the current EC2 instance,
     # we'll peform a signed/authenticated request to Amazon's EC2
@@ -40,19 +42,22 @@ defmodule Peerage.Via.Ec2 do
       |> Map.put("Filter.1.Value.1", instance_id)
       |> describe_endpoint()
       |> SignedUrl.build()
-      |> to_charlist
+      |> to_charlist()
 
-    case :httpc.request(request_uri) do
+    case request(request_uri) do
       {:ok, {{_, 200, _}, _headers, body}} ->
         body
-        |> Xml.parse
+        |> Xml.parse()
         |> Xml.first("//tagSet/item[key='#{tag_name(:cluster)}']/value")
-        |> Xml.text
-      _ -> :error
+        |> Xml.text()
+
+      _ ->
+        :error
     end
   end
 
   defp fetch_running_services(:error), do: :error
+
   defp fetch_running_services(cluster_name) do
     # Having retrieved the cluster_name, we'll peform a
     # signed/authenticated request to Amazon's EC2
@@ -71,24 +76,27 @@ defmodule Peerage.Via.Ec2 do
       |> Map.put("Filter.2.Value.1", cluster_name)
       |> describe_endpoint()
       |> SignedUrl.build()
-      |> to_charlist
+      |> to_charlist()
 
-    case :httpc.request(request_uri) do
+    case request(request_uri) do
       {:ok, {{_, 200, _}, _headers, body}} ->
         instances = Xml.parse(body)
 
-        Enum.map(Xml.all(instances, "//instancesSet/item"), fn(node) ->
-          host = Xml.first(node, "//privateIpAddress") |> Xml.text
-          service = Xml.first(node, "//tagSet/item[key='service']/value") |> Xml.text
+        Enum.map(Xml.all(instances, "//instancesSet/item"), fn node ->
+          host = Xml.first(node, "//privateIpAddress") |> Xml.text()
+          service = Xml.first(node, "//tagSet/item[key='service']/value") |> Xml.text()
           %{host: host, name: service}
         end)
-      _ -> :error
+
+      _ ->
+        :error
     end
   end
 
   defp format_services_list(:error), do: []
+
   defp format_services_list(services) do
-    Enum.map(services, fn(service) ->
+    Enum.map(services, fn service ->
       String.to_atom("#{service.name}@" <> to_string(service.host))
     end)
   end
@@ -98,9 +106,11 @@ defmodule Peerage.Via.Ec2 do
       filters
       |> Map.put("Action", "DescribeInstances")
       |> Map.put("Version", "2016-11-15")
-      |> URI.encode_query
+      |> URI.encode_query()
+
     "https://ec2.amazonaws.com/?" <> query_string
   end
 
+  defp request(uri), do: :httpc.request(:get, {uri, []}, [timeout: 1000], [])
   defp tag_name(key), do: Application.fetch_env!(:peerage_ec2, :tags)[key]
 end

--- a/lib/peerage/via/ec2.ex
+++ b/lib/peerage/via/ec2.ex
@@ -111,6 +111,7 @@ defmodule Peerage.Via.Ec2 do
     "https://ec2.amazonaws.com/?" <> query_string
   end
 
-  defp request(uri), do: :httpc.request(:get, {uri, []}, [timeout: 1000], [])
+  defp request(uri), do: :httpc.request(:get, {uri, []}, [timeout: timeout()], [])
   defp tag_name(key), do: Application.fetch_env!(:peerage_ec2, :tags)[key]
+  defp timeout(), do: Application.get_env(:peerage_ec2, :timeout, 1000)
 end

--- a/lib/peerage/via/ec2/signed_url.ex
+++ b/lib/peerage/via/ec2/signed_url.ex
@@ -11,8 +11,8 @@ defmodule Peerage.Via.Ec2.SignedUrl do
     Returns the current UTC DateTime as NaiveDateTime
     """
     def now() do
-      DateTime.utc_now
-      |> DateTime.to_naive
+      DateTime.utc_now()
+      |> DateTime.to_naive()
     end
   end
 
@@ -49,7 +49,7 @@ defmodule Peerage.Via.Ec2.SignedUrl do
     query_string =
       params
       |> Map.put("X-Amz-Signature", signature)
-      |> URI.encode_query
+      |> URI.encode_query()
       |> String.replace("+", "%20")
 
     "#{uri.scheme}://#{uri.authority}#{uri.path || "/"}?#{query_string}"
@@ -66,34 +66,38 @@ defmodule Peerage.Via.Ec2.SignedUrl do
   end
 
   defp decode_query(query)
-    when is_nil(query), do: Map.new
+       when is_nil(query),
+       do: Map.new()
+
   defp decode_query(query), do: URI.decode_query(query)
 
   defp build_canonical_request(path, params, headers, hashed_payload) do
     query_params =
       params
-      |> URI.encode_query
+      |> URI.encode_query()
       |> String.replace("+", "%20")
 
     header_params =
       headers
-      |> Enum.map(fn({key, value}) -> "#{String.downcase(key)}:#{String.trim(value)}"  end)
+      |> Enum.map(fn {key, value} -> "#{String.downcase(key)}:#{String.trim(value)}" end)
       |> Enum.sort(&(&1 < &2))
       |> Enum.join("\n")
 
     signed_header_params =
       headers
-      |> Enum.map(fn({key, _}) -> String.downcase(key)  end)
+      |> Enum.map(fn {key, _} -> String.downcase(key) end)
       |> Enum.sort(&(&1 < &2))
       |> Enum.join(";")
 
     encoded_path =
       path
       |> String.split("/")
-      |> Enum.map(fn (segment) -> URI.encode_www_form(segment) end)
+      |> Enum.map(fn segment -> URI.encode_www_form(segment) end)
       |> Enum.join("/")
 
-    "GET\n#{encoded_path}\n#{query_params}\n#{header_params}\n\n#{signed_header_params}\n#{hashed_payload}"
+    "GET\n#{encoded_path}\n#{query_params}\n#{header_params}\n\n#{signed_header_params}\n#{
+      hashed_payload
+    }"
   end
 
   defp build_string_to_sign(canonical_request, timestamp, scope) do
@@ -126,24 +130,27 @@ defmodule Peerage.Via.Ec2.SignedUrl do
   defp bytes_to_string(bytes), do: Base.encode16(bytes, case: :lower)
 
   defp format_time(time) do
-    formatted_time = time
-    |> NaiveDateTime.to_iso8601
-    |> String.split(".")
-    |> List.first
-    |> String.replace("-", "")
-    |> String.replace(":", "")
+    formatted_time =
+      time
+      |> NaiveDateTime.to_iso8601()
+      |> String.split(".")
+      |> List.first()
+      |> String.replace("-", "")
+      |> String.replace(":", "")
+
     formatted_time <> "Z"
   end
 
   defp format_date(date) do
     date
-    |> NaiveDateTime.to_date
-    |> Date.to_iso8601
+    |> NaiveDateTime.to_date()
+    |> Date.to_iso8601()
     |> String.replace("-", "")
   end
 
   defp access_key_id(), do: Application.fetch_env!(:peerage_ec2, :aws_access_key_id)
   defp secret_access_key(), do: Application.fetch_env!(:peerage_ec2, :aws_secret_access_key)
+
   defp credential_region() do
     case Application.get_env(:peerage_ec2, :credential_region) do
       nil -> "us-east-1"

--- a/lib/peerage/via/ec2/xml.ex
+++ b/lib/peerage/via/ec2/xml.ex
@@ -6,7 +6,7 @@ defmodule Peerage.Via.Ec2.Xml do
   http://erlang.org/doc/man/xmerl.html
   """
   require Record
-  Record.defrecord :xmlText, Record.extract(:xmlText, from_lib: "xmerl/include/xmerl.hrl")
+  Record.defrecord(:xmlText, Record.extract(:xmlText, from_lib: "xmerl/include/xmerl.hrl"))
 
   @doc """
   Parse a charlist containing an XML document using xmerl_scan.

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Peerage.Via.Ec2.Mixfile do
 
   def project do
     [app: :peerage_ec2,
-     version: "1.1.0",
+     version: "1.2.0",
      elixir: "~> 1.5",
      start_permanent: Mix.env == :prod,
      deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -2,18 +2,20 @@ defmodule Peerage.Via.Ec2.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :peerage_ec2,
-     version: "1.2.0",
-     elixir: "~> 1.5",
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
-     name: "Peerage EC2",
-     package: package(),
-     description: description(),
-     source_url: "https://github.com/BoweryFarming/peerage_ec2",
-     homepage_url: "https://github.com/BoweryFarming/peerage_ec2",
-     docs: [main: "readme", extras: ["README.md"]],
-     elixirc_paths: elixirc_paths(Mix.env)]
+    [
+      app: :peerage_ec2,
+      version: "1.2.0",
+      elixir: "~> 1.5",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      name: "Peerage EC2",
+      package: package(),
+      description: description(),
+      source_url: "https://github.com/BoweryFarming/peerage_ec2",
+      homepage_url: "https://github.com/BoweryFarming/peerage_ec2",
+      docs: [main: "readme", extras: ["README.md"]],
+      elixirc_paths: elixirc_paths(Mix.env())
+    ]
   end
 
   # Run "mix help compile.app" to learn about applications.
@@ -25,17 +27,26 @@ defmodule Peerage.Via.Ec2.Mixfile do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
-    [{:peerage, "~> 1.0"}, # Easy Elixir clusters, pluggable discovery
-     {:ex_doc, "~> 0.18.1", only: :dev}, # ExDoc is a documentation generation tool for Elixir
-     {:mock, "~> 0.2.0", only: :test}] # A mocking library for the Elixir language
+    # Easy Elixir clusters, pluggable discovery
+    [
+      {:peerage, "~> 1.0"},
+      # ExDoc is a documentation generation tool for Elixir
+      {:ex_doc, "~> 0.18.1", only: :dev},
+      # A mocking library for the Elixir language
+      {:mock, "~> 0.2.0", only: :test}
+    ]
   end
 
   def package do
-    [files: ["lib", "mix.exs", "README*"],
-     maintainers: ["Kevin Sheurs", "Dylan Fareed", "Henry Sztul"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/BoweryFarming/peerage_ec2",
-              "Docs" => "https://hexdocs.pm/peerage_ec2/readme.html"}]
+    [
+      files: ["lib", "mix.exs", "README*"],
+      maintainers: ["Kevin Sheurs", "Dylan Fareed", "Henry Sztul"],
+      licenses: ["MIT"],
+      links: %{
+        "GitHub" => "https://github.com/BoweryFarming/peerage_ec2",
+        "Docs" => "https://hexdocs.pm/peerage_ec2/readme.html"
+      }
+    ]
   end
 
   def description do

--- a/test/peerage/via/ec2/signed_url_test.exs
+++ b/test/peerage/via/ec2/signed_url_test.exs
@@ -7,11 +7,11 @@ defmodule Peerage.Via.Ec2.SignedUrlTest do
 
   describe "build/1" do
     test "returns a signed URL with the expected signature" do
-      with_mock SignedUrl.RequestTime, [now: fn() -> ~N[1980-10-17 01:23:45] end] do
+      with_mock SignedUrl.RequestTime, now: fn -> ~N[1980-10-17 01:23:45] end do
         signed =
           "https://ec2.amazonaws.com/?Action=DescribeInstances&Version=2016-11-15"
           |> SignedUrl.build()
-          |> URI.parse
+          |> URI.parse()
 
         assert signed.host == "ec2.amazonaws.com"
         assert signed.scheme == "https"
@@ -31,7 +31,7 @@ defmodule Peerage.Via.Ec2.SignedUrlTest do
         signed_params =
           signed.query
           |> URI.query_decoder()
-          |> Enum.to_list
+          |> Enum.to_list()
 
         assert signed_params == expected_params
       end
@@ -40,7 +40,7 @@ defmodule Peerage.Via.Ec2.SignedUrlTest do
 
   describe "RequestTime.now/0" do
     test "a current naive date time" do
-      expected = DateTime.utc_now |> DateTime.to_naive
+      expected = DateTime.utc_now() |> DateTime.to_naive()
       now = SignedUrl.RequestTime.now()
       assert now.__struct__ == NaiveDateTime
       diff = NaiveDateTime.diff(now, expected)

--- a/test/peerage/via/ec2/xml_test.exs
+++ b/test/peerage/via/ec2/xml_test.exs
@@ -2,7 +2,7 @@ defmodule Peerage.Via.Ec2.XmlTest do
   use ExUnit.Case, async: true
 
   require Record
-  Record.defrecord :xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
+  Record.defrecord(:xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl"))
 
   import Peerage.Via.Ec2.Xml
 
@@ -14,7 +14,10 @@ defmodule Peerage.Via.Ec2.XmlTest do
   describe "all/2" do
     test "returns all nodes for a given path", %{document: document} do
       parsed = document |> parse
-      results = Enum.map(all(parsed, "//instancesSet/item"), fn(node) -> xmlElement(node, :name) end)
+
+      results =
+        Enum.map(all(parsed, "//instancesSet/item"), fn node -> xmlElement(node, :name) end)
+
       assert results == [:item, :item]
     end
 

--- a/test/peerage/via/ec2_test.exs
+++ b/test/peerage/via/ec2_test.exs
@@ -10,71 +10,102 @@ defmodule Peerage.Via.Ec2Test do
 
   setup do
     metadata_api_url = 'http://169.254.169.254/latest/meta-data/instance-id'
-    cluster_name_url = 'https://ec2.amazonaws.com/?Action=DescribeInstances&Filter.1.Name=instance-id&Filter.1.Value.1=my-instance-id&Version=2016-11-15&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=example%2F19801017%2Fus-east-1%2Fec2%2Faws4_request&X-Amz-Date=19801017T012345Z&X-Amz-Expires=86400&X-Amz-Signature=fd6f96b448eca8bc766772556a99a83f4515a2486ee2946d0e1ac9c49f6ae672&X-Amz-SignedHeaders=host'
-    running_services_url = 'https://ec2.amazonaws.com/?Action=DescribeInstances&Filter.1.Name=instance-state-code&Filter.1.Value.1=16&Filter.2.Name=tag%3Acluster&Filter.2.Value.1=staging&Version=2016-11-15&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=example%2F19801017%2Fus-east-1%2Fec2%2Faws4_request&X-Amz-Date=19801017T012345Z&X-Amz-Expires=86400&X-Amz-Signature=2593cc39b442ec5bf04bc91010a4a809d3b04b5ed772a427c44c1efcac3e094f&X-Amz-SignedHeaders=host'
-    cluster_name_response = File.read!("./test/support/fixtures/fetch_cluster_name.xml") |> to_charlist
-    running_services_response = File.read!("./test/support/fixtures/fetch_running_services.xml") |> to_charlist
 
-    {:ok, metadata_api_url: metadata_api_url, cluster_name_url: cluster_name_url, running_services_url: running_services_url,
-          cluster_name_response: cluster_name_response, running_services_response: running_services_response}
+    cluster_name_url =
+      'https://ec2.amazonaws.com/?Action=DescribeInstances&Filter.1.Name=instance-id&Filter.1.Value.1=my-instance-id&Version=2016-11-15&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=example%2F19801017%2Fus-east-1%2Fec2%2Faws4_request&X-Amz-Date=19801017T012345Z&X-Amz-Expires=86400&X-Amz-Signature=fd6f96b448eca8bc766772556a99a83f4515a2486ee2946d0e1ac9c49f6ae672&X-Amz-SignedHeaders=host'
+
+    running_services_url =
+      'https://ec2.amazonaws.com/?Action=DescribeInstances&Filter.1.Name=instance-state-code&Filter.1.Value.1=16&Filter.2.Name=tag%3Acluster&Filter.2.Value.1=staging&Version=2016-11-15&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=example%2F19801017%2Fus-east-1%2Fec2%2Faws4_request&X-Amz-Date=19801017T012345Z&X-Amz-Expires=86400&X-Amz-Signature=2593cc39b442ec5bf04bc91010a4a809d3b04b5ed772a427c44c1efcac3e094f&X-Amz-SignedHeaders=host'
+
+    cluster_name_response =
+      File.read!("./test/support/fixtures/fetch_cluster_name.xml") |> to_charlist
+
+    running_services_response =
+      File.read!("./test/support/fixtures/fetch_running_services.xml") |> to_charlist
+
+    {:ok,
+     metadata_api_url: metadata_api_url,
+     cluster_name_url: cluster_name_url,
+     running_services_url: running_services_url,
+     cluster_name_response: cluster_name_response,
+     running_services_response: running_services_response}
   end
 
   describe "poll/0" do
-    test "returns a list of instances from EC2", %{metadata_api_url: metadata_api_url, cluster_name_url: cluster_name_url,
-                                                   running_services_url: running_services_url,
-                                                   cluster_name_response: cluster_name_response,
-                                                   running_services_response: running_services_response} do
+    test "returns a list of instances from EC2", %{
+      metadata_api_url: metadata_api_url,
+      cluster_name_url: cluster_name_url,
+      running_services_url: running_services_url,
+      cluster_name_response: cluster_name_response,
+      running_services_response: running_services_response
+    } do
       with_mocks([
-        {RequestTime, [], [now: fn() -> @now end]},
-        {:httpc, [], [request: fn(:get, {url, _}, _, _) ->
-                        case url do
-                          ^metadata_api_url -> successful_response(@instance_id)
-                          ^cluster_name_url -> successful_response(cluster_name_response)
-                          ^running_services_url -> successful_response(running_services_response)
-                        end
-                      end]}]) do
-
+        {RequestTime, [], [now: fn -> @now end]},
+        {:httpc, [],
+         [
+           request: fn :get, {url, _}, _, _ ->
+             case url do
+               ^metadata_api_url -> successful_response(@instance_id)
+               ^cluster_name_url -> successful_response(cluster_name_response)
+               ^running_services_url -> successful_response(running_services_response)
+             end
+           end
+         ]}
+      ]) do
         assert Ec2.poll() == [:"gardiner@172.21.22.53", :"falkner@170.31.21.52"]
       end
     end
 
-    test "returns an empty list when metadata request fails", %{metadata_api_url: metadata_api_url} do
+    test "returns an empty list when metadata request fails", %{
+      metadata_api_url: metadata_api_url
+    } do
       with_mocks([
-        {RequestTime, [], [now: fn() -> @now end]},
-        {:httpc, [], [request: fn(:get, {^metadata_api_url, _}, _, _) -> failed_response() end]}]) do
+        {RequestTime, [], [now: fn -> @now end]},
+        {:httpc, [], [request: fn :get, {^metadata_api_url, _}, _, _ -> failed_response() end]}
+      ]) do
         assert Ec2.poll() == []
       end
     end
 
-    test "returns an empty list when cluster name request fails", %{metadata_api_url: metadata_api_url,
-                                                                    cluster_name_url: cluster_name_url} do
+    test "returns an empty list when cluster name request fails", %{
+      metadata_api_url: metadata_api_url,
+      cluster_name_url: cluster_name_url
+    } do
       with_mocks([
-        {RequestTime, [], [now: fn() -> @now end]},
-        {:httpc, [], [request: fn(:get, {url, _}, _, _) ->
-                        case url do
-                          ^metadata_api_url -> successful_response(@instance_id)
-                          ^cluster_name_url -> failed_response()
-                        end
-                      end]}]) do
-
+        {RequestTime, [], [now: fn -> @now end]},
+        {:httpc, [],
+         [
+           request: fn :get, {url, _}, _, _ ->
+             case url do
+               ^metadata_api_url -> successful_response(@instance_id)
+               ^cluster_name_url -> failed_response()
+             end
+           end
+         ]}
+      ]) do
         assert Ec2.poll() == []
       end
     end
 
-    test "returns an empty list when running services request fails", %{metadata_api_url: metadata_api_url,
-                                                                        cluster_name_url: cluster_name_url,
-                                                                        running_services_url: running_services_url,
-                                                                        cluster_name_response: cluster_name_response} do
+    test "returns an empty list when running services request fails", %{
+      metadata_api_url: metadata_api_url,
+      cluster_name_url: cluster_name_url,
+      running_services_url: running_services_url,
+      cluster_name_response: cluster_name_response
+    } do
       with_mocks([
-        {RequestTime, [], [now: fn() -> @now end]},
-        {:httpc, [], [request: fn(:get, {url, _}, _, _) ->
-                        case url do
-                          ^metadata_api_url -> successful_response(@instance_id)
-                          ^cluster_name_url -> successful_response(cluster_name_response)
-                          ^running_services_url -> failed_response()
-                        end
-                      end]}]) do
-
+        {RequestTime, [], [now: fn -> @now end]},
+        {:httpc, [],
+         [
+           request: fn :get, {url, _}, _, _ ->
+             case url do
+               ^metadata_api_url -> successful_response(@instance_id)
+               ^cluster_name_url -> successful_response(cluster_name_response)
+               ^running_services_url -> failed_response()
+             end
+           end
+         ]}
+      ]) do
         assert Ec2.poll() == []
       end
     end

--- a/test/peerage/via/ec2_test.exs
+++ b/test/peerage/via/ec2_test.exs
@@ -26,10 +26,12 @@ defmodule Peerage.Via.Ec2Test do
                                                    running_services_response: running_services_response} do
       with_mocks([
         {RequestTime, [], [now: fn() -> @now end]},
-        {:httpc, [], [request: fn
-                        ^metadata_api_url -> successful_response(@instance_id)
-                        ^cluster_name_url -> successful_response(cluster_name_response)
-                        ^running_services_url -> successful_response(running_services_response)
+        {:httpc, [], [request: fn(:get, {url, _}, _, _) ->
+                        case url do
+                          ^metadata_api_url -> successful_response(@instance_id)
+                          ^cluster_name_url -> successful_response(cluster_name_response)
+                          ^running_services_url -> successful_response(running_services_response)
+                        end
                       end]}]) do
 
         assert Ec2.poll() == [:"gardiner@172.21.22.53", :"falkner@170.31.21.52"]
@@ -39,7 +41,7 @@ defmodule Peerage.Via.Ec2Test do
     test "returns an empty list when metadata request fails", %{metadata_api_url: metadata_api_url} do
       with_mocks([
         {RequestTime, [], [now: fn() -> @now end]},
-        {:httpc, [], [request: fn(^metadata_api_url) -> failed_response() end]}]) do
+        {:httpc, [], [request: fn(:get, {^metadata_api_url, _}, _, _) -> failed_response() end]}]) do
         assert Ec2.poll() == []
       end
     end
@@ -48,9 +50,11 @@ defmodule Peerage.Via.Ec2Test do
                                                                     cluster_name_url: cluster_name_url} do
       with_mocks([
         {RequestTime, [], [now: fn() -> @now end]},
-        {:httpc, [], [request: fn
-                        ^metadata_api_url -> successful_response(@instance_id)
-                        ^cluster_name_url -> failed_response()
+        {:httpc, [], [request: fn(:get, {url, _}, _, _) ->
+                        case url do
+                          ^metadata_api_url -> successful_response(@instance_id)
+                          ^cluster_name_url -> failed_response()
+                        end
                       end]}]) do
 
         assert Ec2.poll() == []
@@ -63,10 +67,12 @@ defmodule Peerage.Via.Ec2Test do
                                                                         cluster_name_response: cluster_name_response} do
       with_mocks([
         {RequestTime, [], [now: fn() -> @now end]},
-        {:httpc, [], [request: fn
-                        ^metadata_api_url -> successful_response(@instance_id)
-                        ^cluster_name_url -> successful_response(cluster_name_response)
-                        ^running_services_url -> failed_response()
+        {:httpc, [], [request: fn(:get, {url, _}, _, _) ->
+                        case url do
+                          ^metadata_api_url -> successful_response(@instance_id)
+                          ^cluster_name_url -> successful_response(cluster_name_response)
+                          ^running_services_url -> failed_response()
+                        end
                       end]}]) do
 
         assert Ec2.poll() == []


### PR DESCRIPTION
`:httpc.request` (http://erlang.org/doc/man/httpc.html) defaults timeouts to `Infinity`. I suspect this is what we've seen with the occasional failed deployments.

Rather than raise an exception, setting this to something reasonable will return an `{:error, :timeout}` tuple which `poll()` can handle.