### PR TITLE
bump version to 2.1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Peerage.Via.Ec2.Mixfile do
   def project do
     [
       app: :peerage_ec2,
-      version: "2.0.0",
+      version: "2.1.0",
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
I forgot to bump the version in [this pr](https://github.com/BoweryFarming/peerage_ec2/pull/16).